### PR TITLE
Add AI assistant skill for shader authoring and porting

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,18 @@ Both are compiled by the test suite on every build, so they cannot drift out
 of sync with the grammar. See [`examples/README.md`](examples/README.md) for
 how to apply one.
 
+## AI assistant skill
+
+`skills/dynamicfx-shaders/` is a skill for AI coding assistants (Claude Code, Cursor, and similar) that teaches them the envelope syntax, the shader ABI, `@param` declarations, and how to port existing Shadertoy/GLSL shaders to DynamicFX. One-line install from your project root:
+
+```bash
+mkdir -p .claude/skills/dynamicfx-shaders && for f in SKILL.md porting.md reference.md; do curl -fsSL "https://raw.githubusercontent.com/JUNKDOGE-JOE/dynamicfx/main/skills/dynamicfx-shaders/$f" -o ".claude/skills/dynamicfx-shaders/$f"; done
+```
+
+Or paste this to your assistant: *Download SKILL.md, porting.md and reference.md from https://raw.githubusercontent.com/JUNKDOGE-JOE/dynamicfx/main/skills/dynamicfx-shaders/ and save all three into .claude/skills/dynamicfx-shaders/ in this project, then confirm the skill is installed.*
+
+See [skills/dynamicfx-shaders/INSTALL.md](skills/dynamicfx-shaders/INSTALL.md) for details.
+
 ## Scripting: wait for readiness before you render
 
 If a script applies DynamicFx and writes the `Source` expression, it must

--- a/skills/dynamicfx-shaders/INSTALL.md
+++ b/skills/dynamicfx-shaders/INSTALL.md
@@ -1,0 +1,34 @@
+# Installing the DynamicFX Shader Skill
+
+This folder is an AI-agent skill that teaches AI coding assistants (Claude Code, Cursor, etc.) how to write and port shaders for the [DynamicFX](https://github.com/JUNKDOGE-JOE/dynamicfx) After Effects plugin.
+
+> **Note:** The one-line installers below assume this folder is published at `skills/dynamicfx-shaders/` on the repository's `main` branch. Until then, copy the folder manually.
+
+## One-line install (paste to your AI assistant)
+
+**English:**
+
+> Download SKILL.md, porting.md and reference.md from https://raw.githubusercontent.com/JUNKDOGE-JOE/dynamicfx/main/skills/dynamicfx-shaders/ and save all three into .claude/skills/dynamicfx-shaders/ in this project, then confirm the skill is installed.
+
+**中文：**
+
+> 请下载 https://raw.githubusercontent.com/JUNKDOGE-JOE/dynamicfx/main/skills/dynamicfx-shaders/ 目录下的 SKILL.md、porting.md、reference.md 三个文件，保存到本项目 .claude/skills/dynamicfx-shaders/ 目录，完成后确认 skill 已安装。
+
+## One-line install (shell)
+
+```bash
+mkdir -p .claude/skills/dynamicfx-shaders && for f in SKILL.md porting.md reference.md; do curl -fsSL "https://raw.githubusercontent.com/JUNKDOGE-JOE/dynamicfx/main/skills/dynamicfx-shaders/$f" -o ".claude/skills/dynamicfx-shaders/$f"; done
+```
+
+Install to `~/.claude/skills/dynamicfx-shaders/` instead for user-wide availability across all projects.
+
+## After installing
+
+Ask your AI assistant things like:
+
+- "Convert this Shadertoy shader to DynamicFX" (paste the shader)
+- "Batch-convert every .glsl file in ./shaders to DynamicFX format"
+- "Write a DynamicFX shader that does <effect> with keyframeable controls"
+- "My DynamicFX Source expression fails with E32 — fix it"
+
+The assistant will follow the skill's envelope/ABI rules, validation checklist, and porting tables instead of guessing.

--- a/skills/dynamicfx-shaders/SKILL.md
+++ b/skills/dynamicfx-shaders/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: dynamicfx-shaders
+description: Use when writing, converting, or debugging shaders for the DynamicFX After Effects plugin — porting Shadertoy/GLSL code to it, authoring @dynamicfx envelope shaders from scratch, declaring AE parameter controls (@param), or when a DynamicFX Source expression fails to compile or is rejected by AE (E6/E7/E18/E32/E53).
+---
+
+# DynamicFX Shaders
+
+## Overview
+
+DynamicFX turns a GLSL shader into a real GPU-accelerated After Effects effect by embedding it as text inside an expression on the effect's numeric `Source` parameter. There is no shader editor UI, no text field, no code panel — the **committed expression string is the single source of truth**.
+
+Core mental model: the final deliverable is always one expression of the shape
+
+```
+`<envelope-source>`;0
+```
+
+— a backtick-delimited template string containing the shader source, followed by `;0` so the expression evaluates to a number (required because `Source` is a numeric parameter; AE rejects the expression without it).
+
+Applying it: Effect > DynamicFx > DynamicFx, then Alt-click the `Source` stopwatch and paste the wrapped string into the expression editor.
+
+## These do NOT exist in DynamicFX
+
+An AI without this skill reliably invents the following. None of them are real. Do not use them.
+
+| Invented / assumed | Reality |
+|---|---|
+| `mainImage(out vec4 fragColor, in vec2 fragCoord)` Shadertoy entry point, "compatibility mode" | Every pass is plain GLSL 450: `void main()` writing to `outColor` (see ABI header below). There is no Shadertoy compatibility layer. |
+| `iTime`, `iResolution`, `iChannel0`, `iMouse`, `iFrame` as built-ins | None of these exist. Map them: `iTime`→`u_time`, `iResolution.xy`→`u_resolution`, `iChannel0` sampling →`texture(sampler2D(u_in, u_s), uv)`, `iMouse`→a `@param` vec2 point control, `iFrame`→`int(u_frame)`. |
+| `// @slider min max default` or similar shorthand annotation | The real syntax is `// @param <id> label:"..." min:0 max:10 default:2` (see @param table below). Misspelled entries reject the whole definition — there is no lenient shorthand. |
+| Standalone `uniform float speed;` declarations | User parameters MUST be fields inside the single `FxUniforms` uniform block, after the three reserved fields `u_resolution`, `u_time`, `u_frame`. A parameter declared outside the block is not a parameter. |
+| A "Shader Code" text parameter, an "Edit Code" button, a code panel in the Effect Controls UI | Does not exist. The only place shader text lives is inside the `Source` expression string, wrapped `` `...`;0 ``. |
+| An "Uniform Bindings" panel, or binding parameters via Slider Control layers/expressions | Does not exist. All parameter binding is declared in-shader via `// @param` comments; AE builds the UI controls from those comments automatically. |
+| Omitting `#version 450` | Every `@pass` body must start with `#version 450`. Without it the pass will not compile. |
+
+## Canonical template
+
+This is the upstream Quick Start example, verbatim. Use it as the starting skeleton for any from-scratch shader.
+
+```glsl
+`@dynamicfx 1
+@graph
+pass main: input -> output
+@end
+@pass main
+#version 450
+// @param speed label:"Speed" min:0 max:4 default:1
+// @param tint label:"Tint" hint:color default:#31C6FF
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 outColor;
+layout(set = 0, binding = 0) uniform texture2D u_in;
+layout(set = 0, binding = 1) uniform sampler u_s;
+layout(set = 0, binding = 2) uniform FxUniforms {
+    vec2 u_resolution;
+    float u_time;
+    float u_frame;
+    float speed;
+    vec4 tint;
+};
+void main() {
+    vec4 base = texture(sampler2D(u_in, u_s), v_uv);
+    vec3 ramp = tint.rgb * (0.5 + 0.5 * sin(u_time * speed + v_uv.x * 3.0));
+    outColor = vec4(mix(base.rgb, ramp, 0.85), 1.0);
+}
+@endpass
+`;0
+```
+
+Line-by-line, what's fixed vs. what you edit:
+
+| Line(s) | Fixed (never change) | Editable |
+|---|---|---|
+| `` `@dynamicfx 1 `` | Literal text and version `1` | — |
+| `@graph` / `@end` | Literal | The `pass ...` line(s) between them |
+| `pass main: input -> output` | Keyword order `pass NAME: INPUT[, INPUT] -> OUTPUT` | `main`, input list, output name (as long as an envelope-consistent name) |
+| `@pass main` / `@endpass` | Literal, name must match graph | — |
+| `#version 450` | Literal, must be first line of pass body | — |
+| `// @param ...` lines | `// @param` prefix and entry syntax | id, label, min/max/default/hint/alias values |
+| `layout(...) in/out/uniform ...` block through `};` | Every line except the user-parameter fields added inside `FxUniforms` | Which extra fields you add inside `FxUniforms`, matched 1:1 with `@param` lines |
+| `void main() { ... }` | Function signature `void main()`, writing to `outColor` | Everything inside the body |
+| `` `;0 `` | Literal, mandatory suffix | — |
+
+## Authoring from scratch — checklist
+
+1. **Envelope**: write `@dynamicfx 1` as line 1, then `@graph` ... `pass main: input -> output` ... `@end`. Add more `pass` lines if using multiple passes, `prev`, or extra inputs.
+2. **Graph**: for each pass, declare `pass NAME: IN1[, IN2...] -> OUT`. Exactly one pass across the whole graph must write `output`. Do not use `input`, `output`, or `prev` as a pass name.
+3. **`@pass` blocks**: one `@pass NAME` / `@endpass` pair per graph entry, same names, same order not required but names must match exactly.
+4. **ABI header**: in every pass body, `#version 450` first, then the fixed `v_uv` in/`outColor` out layout lines, then `u_in`/`u_s` at binding 0/1, then `FxUniforms` at binding 2 with `u_resolution, u_time, u_frame` first and in that order.
+5. **`@param` for every user-facing value**: one `// @param` comment per uniform field you add to `FxUniforms`, placed near its declaration. Never leave a magic number un-parameterized if the user should be able to animate/tweak it.
+6. **Extra inputs**: any additional pass input beyond the first binds sequentially at binding 3, 4, 5 (manifest order). `hint:layer`/`hint:gradient`/`hint:path` parameters are separate from this — see reference.md.
+7. **Body**: write the GLSL logic, sampling with `texture(sampler2D(u_in, u_s), uv)`.
+8. **Wrap**: enclose the whole thing in backticks and append `;0`. Paste into the `Source` expression.
+
+## Quick reference
+
+**Reserved uniforms (fixed order, always present):**
+
+| Name | Type | Meaning |
+|---|---|---|
+| `v_uv` | `vec2` (in) | 0..1 UV covering the full frame |
+| `outColor` | `vec4` (out) | pass output color |
+| `u_in` | `texture2D`, binding 0 | first pass input |
+| `u_s` | `sampler`, binding 1 | sampler for all texture inputs |
+| `u_resolution` | `vec2`, in `FxUniforms` | logical full-resolution size (constant across preview res) |
+| `u_time` | `float`, in `FxUniforms` | layer time in seconds |
+| `u_frame` | `float`, in `FxUniforms` | layer time in frames |
+
+**Reserved pass/graph names:** `input` (source layer), `output` (must be written by exactly one pass), `prev` (previous frame's output, feedback only). None of these may be used as a custom pass name or as an output target for a parameter-fed resource (layer/gradient/path) — violating this is `E6`. `dfx_` is a reserved identifier prefix — do not name anything with it. A pass need not read `input` at all — `prev` may be a pass's only input (e.g. `pass gen: prev -> t`). An empty input list (`pass name: -> out`) is invalid (E6), and `prev` can never be written to.
+
+**`@param` entries:** `label:"text"`, `min:`, `max:`, `default:<value>` (number, `#RRGGBB`, or `#RRGGBBAA` for `hint:color`), `alias:<old-id>` (renames while preserving keyframes), `hint:angle|color|bool|layer|gradient|point3d|path`. Any misspelled entry (e.g. `mim:0`) rejects the whole `@param` definition — parsing is fail-closed, never silently ignored. Full type-mapping and pool-capacity table: see reference.md.
+
+**Capacity limits:** 16 passes max, 4 inputs per pass max, 15 intermediate textures max, 4 MiB max source size. Per-type parameter pool ceilings are in reference.md; exceeding any one pool rejects the whole shader with `E32`.
+
+**Feedback (`prev`):** requires `// @window N` (default 16, max 64) inside the pass that consumes `prev`. Each frame is deterministically re-simulated from black for `min(frame+1, N)` iterations — preview, render queue, and `aerender` all match bit-for-bit. `prev` cannot coexist with `layer`/`path` inputs in the same graph (`E7`).
+
+**Error codes:**
+
+| Code | Meaning |
+|---|---|
+| E6 | Envelope syntax violation (reported with line number), or a parameter-fed resource (layer/gradient/path) used as a pass name/output |
+| E7 | `prev` feedback combined with a `layer`/`path` input in the same graph |
+| E18 | A texture binding declared in a pass that the `@graph` manifest doesn't feed |
+| E32 | A parameter pool exceeded its slot ceiling |
+| E53 | PublicationPending — compiled but not yet published; not renderable yet |
+
+Full diagnostics (Status line, Show Full Status, log file, scripting readiness poll) are in reference.md.
+
+## Validation checklist
+
+Run this before delivering any DynamicFX shader (new or ported):
+
+- [ ] First line is exactly `@dynamicfx 1`
+- [ ] Exactly one pass across the whole graph writes `output`
+- [ ] Every `@pass NAME` has a matching `pass NAME: ...` line in `@graph`, and vice versa
+- [ ] Every pass body starts with `#version 450`
+- [ ] ABI header present in every pass, with `u_resolution`, `u_time`, `u_frame` first and in that order inside `FxUniforms`
+- [ ] Every user-tunable value is a field inside `FxUniforms` (never a standalone `uniform`) and has a matching `// @param` comment
+- [ ] Extra pass inputs bind sequentially at binding 3, 4, 5 in the same order they appear in the `@graph` manifest line
+- [ ] If a pass uses `prev`, it has `// @window N` (N ≤ 64) and the graph has no `layer`/`path` input
+- [ ] No `input`/`output`/`prev` used as a custom pass name; no `dfx_`-prefixed identifiers
+- [ ] Entire source is wrapped in backticks with the final expression ending `` `;0 ``
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| AE rejects the expression outright | Missing trailing `;0`, or unmatched backtick | End with `` `;0 `` exactly; verify only one opening and one closing backtick around the whole source |
+| Compile error citing `mainImage` or "no main function" | Kept a Shadertoy `mainImage` signature | Rewrite as `void main()` writing `outColor`, per the ABI header |
+| Undeclared identifier `iTime`/`iResolution`/`iChannel0` | Left Shadertoy built-ins in place | Map to `u_time` / `u_resolution` / `texture(sampler2D(u_in, u_s), uv)` — see porting.md |
+| `@param` line silently has no effect / whole shader rejected | Typo'd entry key (`mim:`, `lable:`) | Fix the entry key; parsing is fail-closed, re-check spelling against reference.md's entry table |
+| Parameter doesn't appear in Effect Controls | Declared a standalone `uniform`, not a field inside `FxUniforms` | Move the field inside `FxUniforms`, keep the `// @param` comment near it |
+| `E6` on submit | Envelope malformed: pass name mismatch, missing `@end`/`@endpass`, no pass writing `output`, or reserved name misused | Re-check `@graph` vs. `@pass` names line by line; confirm exactly one `-> output` |
+| `E7` on submit | `prev` used together with a `layer` or `path` input in the same graph | Remove one of the two, or split into a graph that doesn't mix them |
+| `E18` on submit | A `layout(... binding = N) uniform texture2D` declared for an input the `@graph` line doesn't list | Add the missing input to the pass's manifest line, matching binding order |
+| `E32` on submit | Too many parameters of one type (see reference.md pool table) | Merge or drop parameters of that type; pools are per-type, not shared |
+| Status shows `E53` / effect passes through unrendered | PublicationPending — shader compiled but not yet published; a few-second window after submit | Wait; for scripting, poll readiness (`fx.property(5).value % 4 === 1`) instead of assuming immediate readiness — see reference.md |
+| Shader looks vertically flipped vs. the original | Coordinate origin convention differs from the source (e.g. Shadertoy) | Try `uv.y = 1.0 - uv.y`; verify visually, there is no documented universal rule |
+
+## Further reading
+
+**Converting existing shaders? REQUIRED: read porting.md** — symbol mapping table, structural decisions (single vs. multi-pass, feedback loops), parameterization conventions, a full worked Shadertoy→DynamicFX example, and the batch-conversion workflow.
+
+**Full parameter tables, limits, scripting, diagnostics: reference.md** — complete `@param` type/hint mapping with pool capacities, gradient/path texture read patterns, all capacity limits, full E-code table, diagnostic channels, scripting readiness polling, plugin install/platform support.

--- a/skills/dynamicfx-shaders/porting.md
+++ b/skills/dynamicfx-shaders/porting.md
@@ -1,0 +1,106 @@
+# DynamicFX Porting Guide
+
+Guidance for converting existing shaders (chiefly Shadertoy) into DynamicFX's `@dynamicfx` envelope + ABI v1 format. Read this after SKILL.md's canonical template and validation checklist.
+
+## Symbol mapping
+
+| Source (Shadertoy / generic GLSL) | DynamicFX equivalent | Notes |
+|---|---|---|
+| `void mainImage(out vec4 fragColor, in vec2 fragCoord)` | `void main()` writing `outColor` | Signature and output variable both change |
+| `fragCoord` | `v_uv * u_resolution` | Only needed if pixel-space coords are required; most logic can work directly in UV space |
+| `fragCoord / iResolution.xy` | `v_uv` | Same normalized UV, use `v_uv` directly instead of recomputing |
+| `iResolution.xy` | `u_resolution` | `iResolution` is `vec3` in Shadertoy; DynamicFX has no `.z` (pixel aspect) equivalent — usually safe to drop |
+| `iTime` | `u_time` | Seconds, layer time |
+| `iFrame` | `int(u_frame)` | `u_frame` is a float; cast if an int is needed |
+| `texture(iChannel0, uv)` / `texture2D(iChannel0, uv)` | `texture(sampler2D(u_in, u_s), uv)` | `u_in`/`u_s` are separate texture/sampler objects combined at the call site |
+| Extra `iChannel1..3` | Extra pass input (binding 3/4/5) or a `hint:layer` parameter | Depends on whether the source is another pass in the same graph or a user-selected layer — see "Structural classification" below |
+| `iMouse` | A `// @param` `vec2` control (0..1 point) | DynamicFX has no live pointer input; expose mouse-driven values as a keyframeable parameter instead. Multiply by `u_resolution` if pixel space is needed |
+| `iDate`, audio (`iChannel` waveform/FFT textures), keyboard textures, cubemaps | No equivalent | Flag for manual decision; cannot be auto-ported |
+| `iChannelResolution[n]` | `textureSize(sampler2D(u_in, u_s), 0)` (or the relevant input's sampler) | |
+| `precision ...;` qualifiers | Delete | Not used in GLSL 450 core-profile ABI |
+| `texture2D(sampler, uv)` (GLSL ES 1.00 call form) | `texture(sampler2D(tex, samp), uv)` | Also add `#version 450` as the first line of the pass body |
+
+## Coordinate system note
+
+Shadertoy's `fragCoord`/`iResolution` convention places the origin at the bottom-left. Whether DynamicFX's `v_uv` origin matches is not documented upstream — **verify visually after conversion**. If the image appears vertically flipped, apply `uv.y = 1.0 - uv.y` as an empirical fix, not as an assumed default.
+
+## Structural classification
+
+Classify each source shader before converting:
+
+| Source structure | DynamicFX target |
+|---|---|
+| Single Shadertoy `mainImage`, no extra buffers | Single-pass envelope (`pass main: input -> output`) |
+| Multiple Shadertoy buffers (Buffer A, B, C, D feeding the main image) | Multi-pass `@graph`: one `@pass` per buffer, buffer names become intermediate pass/texture names, main image becomes the pass that writes `output` |
+| A buffer reads its own previous frame (feedback loop) | `prev` input on that pass + `// @window N`. Note this is a **windowed re-simulation**, not infinite accumulation: history beyond `N` frames (max 64) disappears every re-render. Evaluate whether the original effect depends on unbounded history — if so, flag this as a semantic gap rather than silently truncating it. `prev` cannot be combined with a `layer`/`path` input in the same graph (E7). If the buffer never samples the source layer, `prev` may be the pass's only input (`pass main: prev -> output`) |
+| Uses `iMouse`, keyboard, or audio input | Downgrade interactive input to a `@param` (mouse → point parameter) or mark as **not portable** if there's no reasonable static/keyframeable substitute |
+
+## Parameterization conventions
+
+When porting, scan the source for magic constants that a user would plausibly want to tune: speeds, intensities, radii, thresholds, colors. Promote each to a `// @param`:
+
+- Numeric magic constant `X` → `min:0 max:<4×X> default:<X>` as a starting range (empirical convention, not a spec rule — adjust to taste).
+- Color constants (`vec3(r,g,b)` literals used as a fixed color) → `hint:color default:#RRGGBB`.
+- Respect the per-type parameter pool ceilings (see reference.md). If a port would exceed a pool, merge related constants into fewer parameters or drop the least useful ones — do not attempt to "fit" everything and trigger `E32`.
+
+## Worked example
+
+Input (Shadertoy):
+
+```glsl
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+    vec4 tex = texture(iChannel0, uv);
+    float wave = sin(uv.x * 10.0 + iTime * 2.0) * 0.5 + 0.5;
+    float speed = 2.0;
+    fragColor = vec4(mix(tex.rgb, vec3(wave, 0.2, 1.0 - wave), 0.3), tex.a);
+}
+```
+
+Mapping applied:
+- `mainImage(out fragColor, in fragCoord)` → `void main()` / `outColor`
+- `fragCoord / iResolution.xy` → `v_uv` directly (already normalized)
+- `iChannel0` sampling → `texture(sampler2D(u_in, u_s), uv)` (the layer itself is the only input, bound as `u_in`)
+- `iTime` → `u_time`
+- local `float speed = 2.0;` constant → promoted to a `// @param` slider (`min:0 max:8 default:2`, range = 4x convention) and referenced as `speed` from `FxUniforms`
+- `tex.a` preserved unchanged
+- wrapped in the full envelope, ABI header, and `` `;0 `` expression suffix
+
+Output (final DynamicFX `Source` expression):
+
+```glsl
+`@dynamicfx 1
+@graph
+pass main: input -> output
+@end
+@pass main
+#version 450
+// @param speed label:"Speed" min:0 max:8 default:2
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 outColor;
+layout(set = 0, binding = 0) uniform texture2D u_in;
+layout(set = 0, binding = 1) uniform sampler u_s;
+layout(set = 0, binding = 2) uniform FxUniforms {
+    vec2 u_resolution;
+    float u_time;
+    float u_frame;
+    float speed;
+};
+void main() {
+    vec2 uv = v_uv;
+    vec4 tex = texture(sampler2D(u_in, u_s), uv);
+    float wave = sin(uv.x * 10.0 + u_time * speed) * 0.5 + 0.5;
+    outColor = vec4(mix(tex.rgb, vec3(wave, 0.2, 1.0 - wave), 0.3), tex.a);
+}
+@endpass
+`;0
+```
+
+## Batch conversion workflow
+
+When porting many shaders at once:
+
+1. **Inventory**: list every input file/snippet. For each, classify per the "Structural classification" table above (single-pass / multi-pass / feedback / needs-interactive-downgrade / not-portable).
+2. **Convert individually**: for each shader, produce the complete envelope source and save it as `<name>.glsl`. State the delivery format explicitly: the file's full content wrapped as `` `<file-content>`;0 `` is what gets pasted into the `Source` expression.
+3. **Validate each**: run every converted file through SKILL.md's Validation checklist before considering it done.
+4. **Report**: summarize results in three buckets — converted successfully, converted with a flagged manual decision (e.g. windowed feedback, downgraded mouse input), and not portable (no DynamicFX equivalent exists). Never silently change semantics (e.g. truncating infinite feedback history, dropping mouse interactivity) without calling it out to the user.

--- a/skills/dynamicfx-shaders/reference.md
+++ b/skills/dynamicfx-shaders/reference.md
@@ -1,0 +1,133 @@
+# DynamicFX Reference
+
+## @param syntax and type mapping
+
+Full entry syntax: `// @param <identifier> [entry ...]`, placed near the corresponding field inside `FxUniforms`.
+
+| Entry | Form | Applies to |
+|---|---|---|
+| `label:"text"` | quoted display name | all types (ignored by host for `layer`/`gradient`/`point3d`/`path` — see below) |
+| `min:<n>` | number | numeric types |
+| `max:<n>` | number | numeric types |
+| `default:<value>` | number (1-4 components) or `#RRGGBB`/`#RRGGBBAA` | numeric types / `hint:color` only for hex form; 6-digit hex implies alpha 1.0 |
+| `alias:<old-id>` | identifier | any — preserves keyframes across a parameter rename |
+| `hint:` | one of `angle`, `color`, `bool`, `layer`, `gradient`, `point3d`, `path` | see mapping table below |
+
+Parsing is fail-closed: any unrecognized or misspelled entry key rejects the entire `@param` definition (compile error), it is never silently dropped. An `@param` comment that matches no declared uniform field is ignored (no error).
+
+### Type → control mapping and pool capacities
+
+| GLSL type | `hint` | AE control | Pool capacity |
+|---|---|---|---|
+| `float` | (none) | Slider | 48 |
+| `float` | `angle` | Angle dial | 8 |
+| `int` | (none) | Integer slider | 8 |
+| `int` | `bool` | Checkbox | 16 |
+| `vec2` | (none) | Normalized 0..1 point | 12 |
+| `vec3` | (none) | Color | 12 |
+| `vec3` | `point3d` | 3D point (x, y normalized; z in pixels) | 8 |
+| `vec4` | (none) | Color + opacity | Consumes 1 color slot + 1 float slot |
+| — | `layer` | Layer chooser | 4 |
+| — | `gradient` | Gradient (256x1 LUT) | 2 |
+| — | `path` | Mask chooser | 2 |
+
+Exceeding any single pool's ceiling rejects the whole shader with `E32` — pools are independent per type/hint, not shared.
+
+### Binding behavior for resource-hint parameters
+
+- `hint:layer`: not a `FxUniforms` field. It appears as a pass **input** in the `@graph` manifest and gets a `texture2D` binding at 3/4/5 (in manifest order), like any other extra pass input.
+- `hint:gradient`: backed by a 256x1 LUT texture. Sample with `texture(sampler2D(u_ramp, u_s), vec2(t, 0.5))`. Up to 8 color stops per gradient.
+- `hint:path`: backed by an Nx2 `Rgba32Float` vertex texture. Read with `texelFetch` by vertex index; `textureSize(...).x` gives the vertex count. Closed paths repeat the first vertex at the end (a rectangle mask = 5 vertices). When no path is assigned, the texture defaults to 1x2, all zero. Requires GPU support for `FLOAT32_FILTERABLE`.
+
+### Host UI limitations (known, not bugs)
+
+`layer`, `gradient`, `point3d`, and `path` controls display a generic host-assigned name (e.g. "Mask 01") in the Effect Controls panel instead of the shader's `label:` text — After Effects ignores rename requests for these four control types specifically. This does not affect values, keyframes, or rendering.
+
+## Capacity limits (full)
+
+| Limit | Value |
+|---|---|
+| Passes per graph | 16 |
+| Inputs per pass | 4 |
+| Intermediate textures | 15 |
+| Source size | 4 MiB |
+| `float` parameters | 48 |
+| `float` + `hint:angle` parameters | 8 |
+| `int` parameters | 8 |
+| `int` + `hint:bool` parameters | 16 |
+| `vec2` parameters | 12 |
+| `vec3` (color) parameters | 12 |
+| `vec3` + `hint:point3d` parameters | 8 |
+| `vec4` parameters | shares color (12) + float (48) pools, 1 slot each |
+| `hint:layer` parameters | 4 |
+| `hint:gradient` parameters | 2 (max 8 stops each) |
+| `hint:path` parameters | 2 |
+| `prev` feedback window | default 16, max 64 |
+
+## Error codes
+
+| Code | Meaning | Typical fix |
+|---|---|---|
+| E6 | Envelope syntax violation (with line number); or reserved/resource name misuse (using `input`/`output`/`prev`, or a `layer`/`gradient`/`path`-fed name, as a pass name or output) | Re-check `@dynamicfx`/`@graph`/`@end`/`@pass`/`@endpass` structure and pass-name/manifest consistency; rename the offending pass |
+| E7 | `prev` feedback input combined with a `layer` or `path` input in the same graph | Remove one; split into separate graphs/passes if both are needed |
+| E18 | A `texture2D` binding declared in a pass body that the `@graph` manifest doesn't list as an input | Add the missing input to the pass's manifest line, matching binding order |
+| E32 | A parameter type/hint pool exceeded its capacity ceiling | Merge, reduce, or remove parameters of that type — see pool table above |
+| E53 | PublicationPending — shader compiled successfully but has not yet been published to the render pipeline; not renderable yet | Wait a few seconds; for scripts, poll readiness instead of assuming immediate availability (see below) |
+
+Submitting a shader has a short unready window (a few seconds) after which renders during that window silently pass the original layer through unmodified.
+
+## Diagnostics
+
+- **Status line**: Effect Controls panel, truncated to 31 characters.
+- **Show Full Status** button: opens the full error text including the E-code.
+- **Log file**: `%TEMP%\dynamicfx.log`.
+- Additional verbosity/perf environment toggles: `DYNAMICFX_VERBOSE_LOG`, `DYNAMICFX_PERF`.
+
+## Scripting: readiness polling
+
+The effect's 5th property is a StateToken (`(payload << 2) | state`). State `1` means renderable. Never block the main thread with `$.sleep()` while waiting — it starves the idle-time compile hook DynamicFX relies on. Poll instead with `app.scheduleTask`:
+
+```javascript
+function dfxIsReady(fx) {
+    try { return fx.property(5).value % 4 === 1; } catch (e) { return false; }
+}
+
+var DFX_FX = [];
+var DFX_TRIES = 0;
+
+function dfxPoll() {
+    var ready = 0;
+    for (var i = 0; i < DFX_FX.length; i++) {
+        if (dfxIsReady(DFX_FX[i])) { ready++; }
+    }
+    if (ready === DFX_FX.length) {
+        dfxRender();
+    } else if (++DFX_TRIES > 60) {
+        alert("DynamicFX not ready: " + ready + "/" + DFX_FX.length);
+    } else {
+        app.scheduleTask("dfxPoll()", 500, false);
+    }
+}
+
+dfxPoll();
+```
+
+Property 4 (`Status`) holds the human-readable diagnostic string shown in the Effect Controls panel.
+
+## Plugin install (quick reference)
+
+- Download `DynamicFX-<version>-win-x64.zip` from GitHub Releases (contains `DynamicFx.aex`, `INSTALL.txt`, `SHA256SUMS.txt`), or build from source with `cargo build --release`.
+- Install by copying `DynamicFx.aex` into the **version-specific** plug-ins folder, e.g. `C:\Program Files\Adobe\Adobe After Effects 2025\Support Files\Plug-ins\DynamicFx\DynamicFx.aex`, then restart AE. The effect appears under Effect > DynamicFx > DynamicFx.
+- **Never install into the shared `Common\Plug-ins\7.0\MediaCore` folder** — Premiere Pro scans that folder too.
+- From a source build, run `scripts\install.bat <2023|2024|2025|2026>` as administrator. The version argument is required precisely so the plug-in is never copied to MediaCore; the script refuses to overwrite while AfterFX/aerender is running and never deletes, moves, launches, or terminates anything.
+
+## Platform support matrix
+
+| Platform / host | Status |
+|---|---|
+| Windows | Supported |
+| macOS | Planned, not yet available |
+| After Effects 2025 | Verified |
+| After Effects 2026 | Verified |
+| After Effects 2024 | Unverified |
+| After Effects 2023 | Blocked (not supported) |


### PR DESCRIPTION
## What

Adds `skills/dynamicfx-shaders/` — a skill for AI coding assistants (Claude Code, Cursor, and similar) — plus a short README section pointing to it:

- **SKILL.md** — envelope syntax, the fixed shader ABI, an anti-hallucination list of things that do *not* exist in DynamicFX, the canonical template (verbatim copy of the README Quick Start), authoring and validation checklists, and a common-mistakes table keyed to E-codes.
- **porting.md** — Shadertoy/GLSL → DynamicFX symbol mapping, structural classification (single-pass / multi-buffer / feedback via `prev` + `@window`), parameterization conventions, a worked example, and a batch-conversion workflow.
- **reference.md** — full `@param` type/pool tables, capacity limits, E-code table, diagnostics, scripting readiness polling, and install quick reference.
- **INSTALL.md** — one-line install instructions (shell one-liner and a paste-to-your-assistant prompt, English and Chinese).

## Why

Without guidance, AI assistants reliably invent DynamicFX syntax: they keep Shadertoy's `mainImage`/`iTime`/`iChannel0`, make up `@slider` annotations and a "Uniform Bindings" panel, and miss the envelope and the `` `...`;0 `` expression wrapping entirely (observed in baseline testing). With the skill loaded, the same conversion tasks produce correct envelopes, ABI headers, and `@param` declarations, and semantic gaps (windowed re-simulation vs. infinite accumulation, `iMouse` downgrade) get flagged to the user instead of silently changed.

## Verification

- Every factual claim in the skill was cross-checked against this repo's sources: `grammar.rs` (envelope state machine, pass limits, `prev`-only inputs, empty-input rejection), `glsl.rs` (`ABI_HEAD`, uniform order), `binding.rs` (pool capacities), `annotation.rs` (`@window` defaults), `diagnostics.rs`/`lib.rs` (E6/E7/E18/E32/E53), `install.bat` (MediaCore guard), and the README.
- The canonical template in SKILL.md is byte-identical to the README Quick Start example.
- An independent review pass re-verified all of the above against source before this PR was opened.

## Note

The `raw.githubusercontent.com/.../main/...` install URLs in README and INSTALL.md resolve once this branch merges to `main` — INSTALL.md carries an explicit caveat for the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
